### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -83,8 +83,9 @@ pdflatex document.tex
 
 ## CI/CD Pipeline
 
-There is no CI/CD pipeline configured for this repository. Validation is done manually by
-inspecting the generated `document.pdf`.
+The repository has a release workflow (`.github/workflows/release.yaml`) that runs on pushes to
+`main` and delegates to a shared pipeline (`rios0rios0/pipelines`). There is no LaTeX compilation
+or validation CI — correctness is verified manually by inspecting the generated `document.pdf`.
 
 ## Development Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to document the release workflow added since 0.1.1
+
 ## [0.1.1] - 2026-04-28
 
 ### Changed


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.